### PR TITLE
Add docstrings and fix future annotations for onboarding

### DIFF
--- a/grading_pipeline/__init__.py
+++ b/grading_pipeline/__init__.py
@@ -1,3 +1,16 @@
-"""Role-aware multi-agent grading pipeline (scaffold)."""
+"""LENS – Role-aware multi-agent grading pipeline for clinical ED handoff summaries.
+
+Three clinical roles (Physician, Triage Nurse, Bedside Nurse) independently score
+summaries across 8 rubric dimensions, then an orchestrator detects cross-role
+disagreements, optionally adjudicates via LLM, and aggregates final scores.
+
+Supports two scoring engines:
+  - ``heuristic``: keyword-based baseline (no API key needed)
+  - ``llm``: OpenAI-powered scoring with structured JSON output
+
+Entry points:
+  - CLI: ``python -m grading_pipeline --summary "..." --engine heuristic``
+  - Programmatic: ``from grading_pipeline.orchestrator import run_pipeline``
+"""
 
 __all__ = ["config"]

--- a/grading_pipeline/__main__.py
+++ b/grading_pipeline/__main__.py
@@ -1,3 +1,5 @@
+"""Allow running the package directly: ``python -m grading_pipeline``."""
+
 from .cli import main
 
 if __name__ == "__main__":

--- a/grading_pipeline/cli.py
+++ b/grading_pipeline/cli.py
@@ -1,3 +1,14 @@
+"""Command-line interface for the LENS grading pipeline.
+
+Usage examples::
+
+    python -m grading_pipeline --summary "Patient presents with..." --engine heuristic
+    python -m grading_pipeline --summary-file note.txt --engine llm --model gpt-4o
+    python -m grading_pipeline --summary "..." --engine heuristic --format json --pretty
+"""
+
+from __future__ import annotations
+
 import argparse
 import asyncio
 import json
@@ -16,7 +27,12 @@ from .validation import (
 
 
 def _resolve_summary(args: argparse.Namespace) -> str | None:
-    # Treat --summary "" as explicitly provided input; do not fall back.
+    """Read summary text from ``--summary`` flag or ``--summary-file`` path.
+
+    Returns ``None`` if neither was provided (triggers a validation error
+    downstream).  Treats ``--summary ""`` as explicit empty input — does
+    not fall back to ``--summary-file``.
+    """
     if args.summary is not None:
         return args.summary
     if args.summary_file:
@@ -25,10 +41,12 @@ def _resolve_summary(args: argparse.Namespace) -> str | None:
 
 
 def _validate_summary(summary: str | None) -> str:
+    """Thin wrapper around ``validate_summary_text`` for CLI use."""
     return validate_summary_text(summary)
 
 
 def _print_human(result: Dict[str, Any], rubric: Rubric) -> None:
+    """Format and print pipeline results as a human-readable report to stdout."""
     separator = "----------------------------------------"
 
     # Keep one empty line before the formatted report block.
@@ -78,6 +96,7 @@ def _print_human(result: Dict[str, Any], rubric: Rubric) -> None:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser with all pipeline options."""
     parser = argparse.ArgumentParser(
         description="Role-aware multi-agent grading pipeline (orchestrated)."
     )
@@ -132,6 +151,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point.  Parses args, runs the pipeline, and prints output.
+
+    Returns 0 on success, 2 on input validation errors.
+    """
     parser = _build_parser()
     args = parser.parse_args(argv)
 

--- a/grading_pipeline/config.py
+++ b/grading_pipeline/config.py
@@ -1,3 +1,16 @@
+"""Configuration data structures and loaders for rubric and role definitions.
+
+The pipeline requires two JSON config files:
+  - ``config/lens_rubric.json``: defines the 8 evaluation dimensions
+  - ``config/roles.json``: defines the 3 clinical roles with per-dimension
+    weight vectors (``w_prior``) and optional LLM prompt profile paths
+
+This module parses those files into frozen dataclasses used throughout
+the scoring and orchestration layers.
+"""
+
+from __future__ import annotations
+
 import json
 import math
 from dataclasses import dataclass
@@ -7,6 +20,8 @@ from typing import Any, Dict, List
 
 @dataclass(frozen=True)
 class Dimension:
+    """A single rubric evaluation dimension (e.g. "factual_accuracy")."""
+
     id: str
     name: str
     definition: str
@@ -15,16 +30,30 @@ class Dimension:
 
 @dataclass(frozen=True)
 class Rubric:
+    """The full evaluation rubric containing all scoring dimensions."""
+
     rubric_id: str
     dimensions: List[Dimension]
 
     @property
     def dimension_ids(self) -> List[str]:
+        """Return ordered list of dimension ID strings."""
         return [d.id for d in self.dimensions]
 
 
 @dataclass(frozen=True)
 class RoleProfile:
+    """A clinical role's configuration: identity, weights, and LLM profile.
+
+    Attributes:
+        id: Machine-readable identifier (e.g. "physician", "triage_nurse").
+        name: Human-readable role name.
+        persona: One-line persona description used in LLM prompts.
+        w_prior: Per-dimension importance weights, each in [0, 1].
+        prompt_profile: Optional LLM-specific scoring profile loaded from
+            a separate JSON file (empty dict if not provided).
+    """
+
     id: str
     name: str
     persona: str
@@ -33,6 +62,7 @@ class RoleProfile:
 
 
 def load_rubric(path: str | Path) -> Rubric:
+    """Load and parse a rubric JSON file into a ``Rubric`` instance."""
     data = json.loads(Path(path).read_text())
     dims = [
         Dimension(
@@ -47,6 +77,15 @@ def load_rubric(path: str | Path) -> Rubric:
 
 
 def _load_prompt_profile(roles_path: Path, role_item: Dict[str, Any]) -> Dict[str, Any]:
+    """Load a role's LLM prompt profile JSON from disk.
+
+    The ``profile_path`` field in the role config is relative to the
+    directory containing ``roles.json``.  Returns an empty dict if no
+    profile path is specified.
+
+    Raises:
+        ValueError: If the profile file is missing or contains invalid JSON.
+    """
     profile_path = role_item.get("profile_path")
     if not profile_path:
         return {}
@@ -65,6 +104,11 @@ def _load_prompt_profile(roles_path: Path, role_item: Dict[str, Any]) -> Dict[st
 
 
 def _validate_weights(role_id: str, weights: Dict[str, float]) -> None:
+    """Ensure all weight values are finite, in [0, 1], and not all zero.
+
+    Raises:
+        ValueError: On NaN/inf, out-of-range, or all-zero weights.
+    """
     for dim_id, value in weights.items():
         if not math.isfinite(value):
             raise ValueError(
@@ -82,6 +126,19 @@ def _validate_weights(role_id: str, weights: Dict[str, float]) -> None:
 
 
 def load_roles(path: str | Path, dimension_ids: List[str]) -> List[RoleProfile]:
+    """Load role definitions from JSON, validating weights against the rubric.
+
+    Args:
+        path: Path to ``roles.json``.
+        dimension_ids: Expected dimension IDs from the rubric, used to
+            detect missing or extraneous weight keys.
+
+    Returns:
+        List of ``RoleProfile`` instances, one per role in the config.
+
+    Raises:
+        ValueError: On missing/extra dimension weights or invalid weight values.
+    """
     roles_path = Path(path)
     data = json.loads(roles_path.read_text())
 

--- a/grading_pipeline/llm_scoring.py
+++ b/grading_pipeline/llm_scoring.py
@@ -1,3 +1,14 @@
+"""LLM-based scoring engine using the OpenAI Responses API.
+
+Builds role-specific prompts from persona + profile + rubric, sends them
+to OpenAI with a strict JSON schema, and parses the structured response
+into an ``AgentScore``.
+
+The prompt includes global scoring anchors (1-5 scale), hard constraints
+(e.g. missing evidence → score ≤ 2), and the role's full prompt profile
+so the model applies role-appropriate evaluation priorities.
+"""
+
 from __future__ import annotations
 
 import json
@@ -9,6 +20,11 @@ from .scoring import AgentScore, compute_overall_score
 
 
 def _build_score_schema(rubric: Rubric) -> Dict[str, Any]:
+    """Build the JSON schema that constrains the model's output format.
+
+    Returns a schema requiring ``role_id`` (string) and ``score`` (object
+    with one integer 1-5 field per rubric dimension).
+    """
     score_props: Dict[str, Any] = {}
     for dim in rubric.dimensions:
         score_props[dim.id] = {
@@ -34,12 +50,18 @@ def _build_score_schema(rubric: Rubric) -> Dict[str, Any]:
 
 
 def _role_profile_json(role: RoleProfile) -> str:
+    """Serialize the role's LLM prompt profile to a JSON string for prompt injection."""
     if not role.prompt_profile:
         return "{}"
     return json.dumps(role.prompt_profile, ensure_ascii=True, indent=2, sort_keys=True)
 
 
 def _build_instructions(role: RoleProfile, rubric: Rubric) -> str:
+    """Assemble the full system-level instruction prompt for a scoring call.
+
+    Includes: role identity, persona, scoring anchors, hard constraints,
+    the role's prompt profile JSON, and all rubric dimension definitions.
+    """
     lines = [
         "You are scoring a clinical summary for ED handoff.",
         f"Role: {role.name}",
@@ -85,6 +107,24 @@ def score_summary_llm(
     model: str = "gpt-4o-mini",
     temperature: float = 0.2,
 ) -> AgentScore:
+    """Score a clinical summary using an LLM via the OpenAI Responses API.
+
+    Args:
+        summary: The clinical summary text to evaluate.
+        role: The clinical role whose perspective to apply.
+        rubric: The evaluation rubric (defines which dimensions to score).
+        model: OpenAI model identifier.
+        temperature: Sampling temperature (lower = more deterministic).
+
+    Returns:
+        An ``AgentScore`` with per-dimension integer scores and a weighted
+        overall.  Rationales are not returned by this engine (only the
+        heuristic engine produces them).
+
+    Raises:
+        OpenAIClientError: If the API call fails, the response is malformed,
+            or any score is missing / out of range.
+    """
     schema = _build_score_schema(rubric)
     instructions = _build_instructions(role, rubric)
 

--- a/grading_pipeline/openai_client.py
+++ b/grading_pipeline/openai_client.py
@@ -1,3 +1,17 @@
+"""Minimal HTTP client for the OpenAI Responses API.
+
+Uses only stdlib (``urllib``) — no external dependencies.  Handles:
+  - ``.env`` file parsing for ``OPENAI_API_KEY``
+  - Building and sending JSON requests to the Responses API
+  - Extracting structured JSON output from the response
+
+The base URL defaults to ``https://api.openai.com/v1/responses`` but can
+be overridden via the ``OPENAI_BASE_URL`` environment variable (useful for
+proxies or local testing).
+"""
+
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path
@@ -7,6 +21,7 @@ from typing import Any, Dict
 
 
 class OpenAIClientError(RuntimeError):
+    """Raised for any OpenAI API communication or response-parsing failure."""
     pass
 
 
@@ -15,6 +30,7 @@ DOTENV_PATH = PROJECT_ROOT / ".env"
 
 
 def _strip_inline_comment(value: str) -> str:
+    """Remove an inline ``# comment`` from a .env value, respecting quotes."""
     if "#" not in value:
         return value
     in_single = False
@@ -30,6 +46,9 @@ def _strip_inline_comment(value: str) -> str:
 
 
 def _read_dotenv(path: str | Path) -> dict[str, str]:
+    """Parse a ``.env`` file into a dict.  Handles comments, ``export`` prefix,
+    quoted values, and inline comments.  Returns empty dict if file is missing.
+    """
     try:
         raw = Path(path).read_text()
     except FileNotFoundError:
@@ -55,6 +74,11 @@ def _read_dotenv(path: str | Path) -> dict[str, str]:
 
 
 def _resolve_api_key() -> str | None:
+    """Resolve the OpenAI API key: .env file takes priority, then env var.
+
+    If found in .env, the key is also injected into ``os.environ`` so
+    downstream code can access it consistently.
+    """
     dotenv = _read_dotenv(DOTENV_PATH)
     key = dotenv.get("OPENAI_API_KEY")
     if key:
@@ -78,6 +102,15 @@ def create_response(
     json_schema: Dict[str, Any],
     temperature: float = 0.2,
 ) -> Dict[str, Any]:
+    """Send a request to the OpenAI Responses API and return the raw JSON response.
+
+    Uses ``json_schema`` for structured output (strict mode), ensuring the
+    model returns JSON conforming to the provided schema.
+
+    Raises:
+        OpenAIClientError: If the API key is missing, or the request fails
+            with an HTTP or network error.
+    """
     api_key = _resolve_api_key()
     if not api_key:
         raise OpenAIClientError("OPENAI_API_KEY is not set.")
@@ -117,6 +150,15 @@ def create_response(
 
 
 def extract_json_output(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract and parse JSON from an OpenAI Responses API response.
+
+    Handles two response formats:
+      - Shortcut: ``response["output_text"]`` (newer API versions)
+      - Nested: ``response["output"][*]["content"][*]["text"]`` (standard format)
+
+    Raises:
+        OpenAIClientError: If no text output is found or JSON parsing fails.
+    """
     if isinstance(response, dict) and response.get("output_text"):
         text = response["output_text"]
     else:

--- a/grading_pipeline/orchestrator.py
+++ b/grading_pipeline/orchestrator.py
@@ -1,3 +1,18 @@
+"""Core orchestration logic for the multi-agent grading pipeline.
+
+Pipeline stages:
+  1. **Validate** the input summary.
+  2. **Parallel Score**: three clinical roles score independently via
+     ``asyncio.gather()``.
+  3. **Validate Scorecards**: retry any role whose output fails validation
+     (missing dims, out-of-range scores, etc.).
+  4. **Disagreement Map**: compute per-dimension cross-role score gaps.
+  5. **Conditional Adjudication** (LLM mode only): if any gap ≥ threshold,
+     an adjudicator LLM refines disputed dimensions.
+  6. **Aggregate**: compute per-role weighted overalls and cross-role mean.
+  7. **Return** structured result dict.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -11,6 +26,7 @@ from .openai_client import OpenAIClientError, create_response, extract_json_outp
 from .scoring import AgentScore, compute_overall_score, score_summary_heuristic
 from .validation import validate_summary_text
 
+# The 8 canonical rubric dimension IDs, in display order.
 DIMENSION_IDS = [
     "factual_accuracy",
     "relevant_chronic_problem_coverage",
@@ -32,6 +48,7 @@ CANONICAL_ROLE_IDS = ["physician", "triage_nurse", "bedside_nurse"]
 
 
 def _normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
+    """Clip weights to ≥0 and normalize to sum to 1.  Falls back to uniform if all zero."""
     clipped = {dim: max(0.0, float(weights.get(dim, 0.0))) for dim in DIMENSION_IDS}
     total = sum(clipped.values())
     if total <= 0.0:
@@ -42,7 +59,11 @@ def _normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
 def calibrate_weights(
     w_prior: Dict[str, float], delta_w: Dict[str, float] | None = None
 ) -> Dict[str, float]:
-    # Step 5C stub: delta_w is intentionally a no-op for now.
+    """Combine prior weights with an optional delta adjustment and normalize.
+
+    Note: ``delta_w`` is currently a no-op stub (always zeros).  It exists
+    as a hook for future weight calibration logic.
+    """
     if delta_w is None:
         delta_w = {dim: 0.0 for dim in DIMENSION_IDS}
 
@@ -54,10 +75,16 @@ def calibrate_weights(
 
 
 def _to_role_name(role: RoleProfile) -> str:
+    """Map a RoleProfile to its human-readable display name."""
     return ROLE_NAME_BY_ID.get(role.id, role.name.replace(" Agent", ""))
 
 
 def _agent_to_scorecard(agent: AgentScore, role: RoleProfile) -> Dict[str, Any]:
+    """Convert an ``AgentScore`` into the mutable scorecard dict used internally.
+
+    The scorecard format has keys: role, role_id, scores, rationales, overall,
+    and optionally evidence.
+    """
     rationales = agent.rationales or {dim: "" for dim in DIMENSION_IDS}
     scorecard = {
         "role": _to_role_name(role),
@@ -74,6 +101,11 @@ def _agent_to_scorecard(agent: AgentScore, role: RoleProfile) -> Dict[str, Any]:
 
 
 def _validate_scorecard(scorecard: Dict[str, Any]) -> List[str]:
+    """Validate a scorecard dict, returning a list of error strings (empty = valid).
+
+    Checks: recognized role name, all 8 dimensions present with numeric
+    scores in [1, 5], all rationales present as strings, and overall in [1, 5].
+    """
     errors: List[str] = []
 
     role_name = scorecard.get("role")
@@ -120,6 +152,14 @@ def _validate_scorecard(scorecard: Dict[str, Any]) -> List[str]:
 def build_disagreement_map(
     scorecards_by_role_id: Dict[str, Dict[str, Any]], gap_threshold: float
 ) -> Dict[str, Dict[str, Any]]:
+    """Build a per-dimension disagreement map across the three roles.
+
+    For each dimension, computes the score gap (max - min) and flags
+    dimensions where the gap meets or exceeds ``gap_threshold``.
+
+    Returns:
+        Dict mapping dimension_id → {role_scores, score_gap, flag}.
+    """
     disagreement_map: Dict[str, Dict[str, Any]] = {}
 
     for dim in DIMENSION_IDS:
@@ -146,6 +186,15 @@ def _default_adjudicator(
     disputed_dims: List[str],
     model: str,
 ) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """LLM-based adjudicator that refines scores for disputed dimensions.
+
+    Sends the original summary, rubric subset, and all three role scorecards
+    to the LLM, asking it to produce updated scores and rationales *only*
+    for the disputed dimensions.  Uses temperature=0.0 for consistency.
+
+    Returns:
+        Nested dict: ``updates[role_id]["scores"|"rationales"][dim_id]``.
+    """
     score_props = {
         dim: {"type": "number", "minimum": 1, "maximum": 5} for dim in disputed_dims
     }
@@ -235,6 +284,11 @@ def _apply_adjudication_updates(
     updates: Dict[str, Dict[str, Dict[str, Any]]],
     disputed_dims: List[str],
 ) -> None:
+    """Merge adjudicator updates into the live scorecards (in place).
+
+    Only overwrites disputed dimension scores and rationales; non-disputed
+    dimensions are preserved unchanged.
+    """
     for role_id in CANONICAL_ROLE_IDS:
         if role_id not in updates:
             continue
@@ -257,6 +311,12 @@ def _repair_disputed_fields(
     repaired_scorecard: Dict[str, Any],
     disputed_dims: List[str],
 ) -> None:
+    """Copy disputed-dimension fields from a freshly re-scored scorecard into the target.
+
+    Used after post-adjudication validation fails: re-score the role and
+    selectively patch only the disputed dimensions, preserving non-disputed
+    fields from the adjudicated result.
+    """
     for dim in disputed_dims:
         target_scorecard["scores"][dim] = float(repaired_scorecard["scores"][dim])
         target_scorecard["rationales"][dim] = str(
@@ -271,6 +331,12 @@ def _repair_disputed_fields(
 def _aggregate_role_overalls(
     scorecards_by_role_id: Dict[str, Dict[str, Any]], roles_by_id: Dict[str, RoleProfile]
 ) -> float:
+    """Compute per-role weighted overalls and the cross-role mean.
+
+    For each role: calibrates weights, computes weighted average across
+    dimensions, and stores the result back into the scorecard.  Returns
+    the mean of the three role overalls (rounded to 4 decimal places).
+    """
     per_role_overalls: List[float] = []
 
     for role_id in CANONICAL_ROLE_IDS:
@@ -302,6 +368,26 @@ async def run_pipeline(
     role_scorer: Callable[[str, RoleProfile, Rubric], AgentScore] | None = None,
     adjudicator: Callable[..., Dict[str, Dict[str, Dict[str, Any]]]] | None = None,
 ) -> Dict[str, Any]:
+    """Run the full grading pipeline end-to-end.
+
+    Args:
+        summary: Raw clinical summary text.
+        mode: ``"llm"`` or ``"heuristic"``.
+        output_format: ``"human"`` or ``"json"`` (passed through to meta).
+        rubric: Loaded rubric with dimension definitions.
+        roles: List of 3 ``RoleProfile`` instances.
+        model: OpenAI model ID (LLM mode only).
+        temperature: Sampling temperature (LLM mode only).
+        gap_threshold: Min score gap to trigger adjudication.
+        max_retries: Max re-scoring attempts per role on validation failure.
+        role_scorer: Optional override for the per-role scoring function
+            (useful for testing without API calls).
+        adjudicator: Optional override for the adjudication function.
+
+    Returns:
+        Dict with keys: ``per_role_scorecards``, ``disagreement_map``,
+        ``adjudication_ran``, ``overall_across_roles``, ``meta``.
+    """
     if mode not in {"llm", "heuristic"}:
         raise ValueError(f"Unsupported mode: {mode}")
 

--- a/grading_pipeline/scoring.py
+++ b/grading_pipeline/scoring.py
@@ -1,3 +1,21 @@
+"""Heuristic (keyword-based) scoring engine for clinical summaries.
+
+This module provides a fast, deterministic baseline scorer that requires
+no API key.  Each of the 8 rubric dimensions has its own scoring function
+that inspects the summary text for keyword hits, structural markers,
+sentence statistics, and word count.
+
+Scoring flow for one role:
+  1. Run all 8 dimension scorers independently.
+  2. Apply role-specific adjustments (``_apply_role_adjustments``).
+  3. Clamp all scores to [1, 5].
+  4. Compute a weighted overall using the role's ``w_prior`` weights.
+
+Score scale: 1 (worst) to 5 (best) per dimension.
+"""
+
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
@@ -7,6 +25,17 @@ from .config import RoleProfile, Rubric
 
 @dataclass(frozen=True)
 class AgentScore:
+    """Container for a single role's scoring output.
+
+    Attributes:
+        role_id: Which clinical role produced this score.
+        scores: Mapping of dimension_id → integer score (1-5).
+        rationales: Optional per-dimension textual justification.
+        evidence: Optional per-dimension list of matched keywords/evidence.
+        overall_notes: Free-text note about the role's perspective.
+        warnings: Any warnings generated during scoring (e.g. empty input).
+        overall_score: Weighted average across dimensions (computed post-scoring).
+    """
     role_id: str
     scores: Dict[str, int]
     rationales: Dict[str, str] | None = None
@@ -33,6 +62,12 @@ class AgentScore:
             payload["warnings"] = self.warnings
         return payload
 
+
+# ---------------------------------------------------------------------------
+# Keyword lists used by the dimension scorers.
+# Each list targets a specific clinical concept.  Keywords are matched as
+# whole words (word-boundary regex) to avoid false positives from substrings.
+# ---------------------------------------------------------------------------
 
 CHRONIC_KEYWORDS = [
     "diabetes",
@@ -127,20 +162,37 @@ FACTUAL_EVIDENCE_KEYWORDS = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Text analysis helpers
+# ---------------------------------------------------------------------------
+
+
 def _word_count(text: str) -> int:
+    """Count words using word-boundary regex (handles punctuation/hyphens)."""
     return len(re.findall(r"\b\w+\b", text))
 
 
 def _sentence_lengths(text: str) -> List[int]:
+    """Return a list of word counts per sentence (split on `.`, `!`, `?`).
+
+    Returns ``[0]`` for empty text so callers can safely compute averages.
+    """
     sentences = [s.strip() for s in re.split(r"[.!?]+", text) if s.strip()]
     return [len(re.findall(r"\b\w+\b", s)) for s in sentences] or [0]
 
 
 def _keyword_pattern(keyword: str) -> str:
+    """Build a regex that matches *keyword* as a whole word (not a substring)."""
     return rf"(?<!\w){re.escape(keyword)}(?!\w)"
 
 
 def _find_hits(text: str, keywords: List[str]) -> List[str]:
+    """Return which keywords appear in *text* (case-insensitive, whole-word).
+
+    Alphanumeric keywords use word-boundary matching to prevent false
+    positives (e.g. "days" won't match inside "holidays").  Pure
+    punctuation keywords (like "?") use simple substring search.
+    """
     hits: List[str] = []
     lowered = text.lower()
     for kw in keywords:
@@ -153,6 +205,7 @@ def _find_hits(text: str, keywords: List[str]) -> List[str]:
 
 
 def _score_from_hits(count: int) -> int:
+    """Map a keyword hit count to a 1-5 score: 0→1, 1→2, 2-3→3, 4-5→4, 6+→5."""
     if count >= 6:
         return 5
     if count >= 4:
@@ -165,6 +218,11 @@ def _score_from_hits(count: int) -> int:
 
 
 def _score_focus_by_length(word_count: int) -> Tuple[int, str]:
+    """Score the ``focused_not_cluttered`` dimension based on word count.
+
+    Ideal range is 80-200 words (score 5).  Scores decrease as length
+    deviates further from this window in either direction.
+    """
     if 80 <= word_count <= 200:
         return 5, "Length is concise and focused."
     if 50 <= word_count <= 79 or 201 <= word_count <= 260:
@@ -177,6 +235,11 @@ def _score_focus_by_length(word_count: int) -> Tuple[int, str]:
 
 
 def _score_clarity(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``clarity_readability_formatting`` via sentence length and structure markers.
+
+    Starts at 3, +1 for short avg sentences (≤12 words), -1 for long (≥30),
+    +1 if structural markers (bullets, numbered lists, section headers) are present.
+    """
     lengths = _sentence_lengths(text)
     avg_len = sum(lengths) / max(len(lengths), 1)
     markers = [m for m in STRUCTURE_MARKERS if m in text.lower()]
@@ -197,6 +260,11 @@ def _score_clarity(text: str) -> Tuple[int, str, List[str]]:
 
 
 def _score_factual_accuracy(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``factual_accuracy`` using evidence keywords and uncertainty language.
+
+    Starts at 3, +1 for clinical evidence terms, -1 for uncertainty hedges,
+    -1 if very short (<40 words) since brevity risks factual omissions.
+    """
     score = 3
     evidence = _find_hits(text, FACTUAL_EVIDENCE_KEYWORDS)
     uncertainty = _find_hits(text, UNCERTAINTY_KEYWORDS)
@@ -217,6 +285,7 @@ def _score_factual_accuracy(text: str) -> Tuple[int, str, List[str]]:
 
 
 def _score_organized(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``organized_by_condition`` by counting structural markers (bullets, headers)."""
     markers = [m for m in STRUCTURE_MARKERS if m in text.lower()]
     marker_count = len(markers)
     if marker_count >= 4:
@@ -234,6 +303,7 @@ def _score_organized(text: str) -> Tuple[int, str, List[str]]:
 
 
 def _score_timeline(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``timeline_evolution`` by counting temporal keyword hits."""
     hits = _find_hits(text, TEMPORAL_KEYWORDS)
     score = _score_from_hits(len(hits))
     rationale = "Temporal cues help track evolution."
@@ -243,6 +313,7 @@ def _score_timeline(text: str) -> Tuple[int, str, List[str]]:
 
 
 def _score_recent_changes(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``recent_changes_highlighted`` by counting change-related keyword hits."""
     hits = _find_hits(text, RECENT_CHANGE_KEYWORDS)
     score = _score_from_hits(len(hits))
     rationale = "Recent changes are explicitly called out."
@@ -252,6 +323,7 @@ def _score_recent_changes(text: str) -> Tuple[int, str, List[str]]:
 
 
 def _score_chronic_coverage(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``relevant_chronic_problem_coverage`` by counting chronic-condition keyword hits."""
     hits = _find_hits(text, CHRONIC_KEYWORDS)
     score = _score_from_hits(len(hits))
     rationale = "Chronic condition coverage is represented."
@@ -261,6 +333,7 @@ def _score_chronic_coverage(text: str) -> Tuple[int, str, List[str]]:
 
 
 def _score_decision_usefulness(text: str) -> Tuple[int, str, List[str]]:
+    """Score ``usefulness_for_decision_making`` by counting clinical-decision keyword hits."""
     hits = _find_hits(text, DECISION_KEYWORDS)
     score = _score_from_hits(len(hits))
     rationale = "Decision-supporting details are present."
@@ -272,6 +345,11 @@ def _score_decision_usefulness(text: str) -> Tuple[int, str, List[str]]:
 def compute_overall_score(
     scores: Dict[str, int], weights: Dict[str, float], dimension_ids: List[str]
 ) -> float:
+    """Compute a weighted average score across dimensions.
+
+    If total weight is zero (or all weights missing), falls back to a
+    simple unweighted mean.  Result is rounded to 2 decimal places.
+    """
     total_weight = sum(weights.get(dim, 0.0) for dim in dimension_ids)
     if total_weight <= 0:
         total_weight = float(len(dimension_ids) or 1)
@@ -281,6 +359,20 @@ def compute_overall_score(
 
 
 def score_summary_heuristic(summary: str, role: RoleProfile, rubric: Rubric) -> AgentScore:
+    """Score a clinical summary using the keyword-based heuristic engine.
+
+    Runs all 8 dimension scorers, applies role-specific adjustments,
+    clamps to [1, 5], and computes the weighted overall score.
+
+    Args:
+        summary: The clinical summary text to evaluate.
+        role: The clinical role whose perspective to apply.
+        rubric: The evaluation rubric (defines which dimensions to score).
+
+    Returns:
+        An ``AgentScore`` with per-dimension scores, rationales, evidence,
+        and a weighted overall score.
+    """
     summary = summary.strip()
     warnings: List[str] = []
     if not summary:
@@ -354,6 +446,15 @@ def score_summary_heuristic(summary: str, role: RoleProfile, rubric: Rubric) -> 
 def _apply_role_adjustments(
     role_id: str, scores: Dict[str, int], rationales: Dict[str, str]
 ) -> None:
+    """Apply role-specific score adjustments that reflect clinical priorities.
+
+    - **Physician**: penalizes low decision-usefulness (expects richer data).
+    - **Triage Nurse**: penalizes poor focus and clarity (needs fast scanning).
+    - **Bedside Nurse**: boosts recent-changes and decision-usefulness
+      (values actionable care details).
+
+    Modifies *scores* and *rationales* dicts in place.
+    """
     if role_id == "physician":
         if scores["usefulness_for_decision_making"] <= 2:
             scores["usefulness_for_decision_making"] = max(

--- a/grading_pipeline/validation.py
+++ b/grading_pipeline/validation.py
@@ -1,3 +1,10 @@
+"""Input validation for clinical summary text.
+
+Enforces minimum length and non-empty constraints before the summary
+enters the scoring pipeline.  Used by both the CLI layer and the
+orchestrator.
+"""
+
 from __future__ import annotations
 
 MIN_SUMMARY_CHARS = 30
@@ -8,6 +15,18 @@ SHORT_SUMMARY_ERROR = (
 
 
 def validate_summary_text(summary: str | None) -> str:
+    """Validate and clean a raw summary string.
+
+    Args:
+        summary: Raw summary text (may be ``None`` if user omitted input).
+
+    Returns:
+        The whitespace-stripped summary text.
+
+    Raises:
+        ValueError: If ``summary`` is ``None``, empty/whitespace-only,
+            or shorter than ``MIN_SUMMARY_CHARS`` after stripping.
+    """
     if summary is None:
         raise ValueError(EMPTY_SUMMARY_ERROR)
 

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- Add module-level, class, and function docstrings across all 9 source files (`__init__`, `__main__`, `cli`, `config`, `llm_scoring`, `openai_client`, `orchestrator`, `scoring`, `validation`) to make the codebase accessible to new contributors
- Add missing `from __future__ import annotations` imports in 4 source files and 1 test file, fixing `str | Path` and `X | None` syntax compatibility with Python <3.10
- Add inline comments for keyword lists and canonical constants

## Test plan
- [x] All 14 existing tests pass (`pytest -q`)
- [ ] Verify docstrings render correctly in IDE tooltips / `help()`
- [ ] Confirm no functional behavior changes (docstrings and imports only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)