### PR TITLE
Use RELEASE_TOKEN to bypass branch protection in bump-and-release

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history so tag checks are accurate
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Validate semver format
         run: |


### PR DESCRIPTION
## Summary
- Use `RELEASE_TOKEN` (PAT) instead of default `GITHUB_TOKEN` in the checkout step of `bump-and-release.yml`
- The default `GITHUB_TOKEN` cannot push to a protected branch even with bypass actors configured

## Prerequisites
- Create a fine-grained PAT with **Contents (read/write)** permission scoped to `denoslab/LENS`
- Add it as a repository secret named `RELEASE_TOKEN`

## Test plan
- [ ] Merge this PR, then re-run "Bump and Release" workflow
- [ ] Verify the version bump commit and tag are pushed to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)