### PR TITLE
Remove TestPyPI step from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,28 +53,9 @@ jobs:
           name: dist
           path: dist/
 
-  testpypi:
-    name: Publish to TestPyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   pypi:
     name: Publish to PyPI
-    needs: testpypi
+    needs: build
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary
- Remove the TestPyPI publish job from `release.yml`
- Publish directly to PyPI after build validation

Pipeline is now: **test → build → pypi → github-release**

## Test plan
- [ ] Merge, then re-run bump-and-release with a new version
- [ ] Verify the release pipeline publishes to PyPI successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)